### PR TITLE
prevent ProgressBar from allowing values greater than 100

### DIFF
--- a/src/components/ResortInfoCard/ProgressBar.js
+++ b/src/components/ResortInfoCard/ProgressBar.js
@@ -15,7 +15,7 @@ const ProgressBar = ({ small, progress }) => {
     return <span>-</span>
   }
 
-  let width = progress >= 0 ? progress : 0;
+  let width = progress >= 0 ? Math.min(progress, 100) : 0;
 
   if (progress !== undefined) {
     progressBar = (


### PR DESCRIPTION
This prevents ProgressBar from overflowing its container where consumers pass values greater than 100%.